### PR TITLE
fix: Update get_version to use the new package name

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,7 +10,7 @@ from importlib.metadata import version as get_version
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project: str = 'BlueTracker'
+project: str = 'bluetracker-hass-mqtt'
 project_copyright: str = 'essel.dev'
 author: str = 'essel.dev'
 release: str = get_version(project)

--- a/src/bluetracker/utils/mqtt_messages.py
+++ b/src/bluetracker/utils/mqtt_messages.py
@@ -32,7 +32,7 @@ DEVICE: Final = {
     'connections': [['mac', MAC]],
     'manufacturer': 'BlueTracker',
     'name': f'BlueTracker {HOSTNAME.title()}',
-    'sw_version': get_version('BlueTracker'),
+    'sw_version': get_version('bluetracker-hass-mqtt'),
 }
 
 


### PR DESCRIPTION
This change is necessary because the package was renamed from bluetracker to bluetracker-hass-mqtt to avoid a conflict on PyPI.